### PR TITLE
Add option to use form sign in (#148) - for development purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Gate works by automating OpenVPN profile creation for you and also providing you
   * Update the client_id and client_secret to `GATE_OAUTH_CLIENT_ID` and `GATE_OAUTH_CLIENT_SECRET` respectively
   * Update your `GATE_SERVER_URL` to `http://localhost:3000`
   * Specify your email domain for `GATE_EMAIL_DOMAIN` and `GATE_HOSTED_DOMAINS`, for instance if you are your email address is  `test123@gmail.com` then the values would be `gmail.com`
+  * Leave `SIGN_IN_TYPE` to empty value
 
 #### Finishing Setup
 To finish with your setup you just need to run `rake app:setup` this would setup your database and also run the inital set of tests to make sure you have a successful setup.
@@ -101,3 +102,8 @@ NEWRELIC_AGENT_ENABLED              - Set it true if you want Newrelic agent to 
 Gate has several tasks that can be scheduled for maintenance purpose. Please see `config/scheduler.rb` to see the list of tasks.
 
 You may have to run `whenever --update-crontab` to update cronjob so that it run these tasks. Gate utilize `whenever` gem for maintaining scheduled tasks, which in turn utilize cronjob as its backend.
+
+### Development note
+When you're in development and need to bypass oAuth sign in you can update your `SIGN_IN_TYPE` to `form`. Note that you still need to update `GATE_HOSTED_DOMAINS` to serve your email domain.
+
+This option will provide you with sign in form in the homepage that you can fill with your email and name to sign in.

--- a/app/controllers/users/auth_controller.rb
+++ b/app/controllers/users/auth_controller.rb
@@ -1,0 +1,20 @@
+class Users::AuthController < ApplicationController
+  before_action :set_paper_trail_whodunnit
+
+  def log_in
+    unless Figaro.env.sign_in_type == 'form'
+      return redirect_to root_path
+    end
+
+    email = params.require(:email)
+    name = params.require(:name)
+
+    unless User.valid_domain? email.split('@').last
+      return render plain: 'Your domain is unauthorized', status: :unauthorized
+    end
+
+    user = User.create_user(name, email)
+    user.generate_two_factor_auth
+    sign_in_and_redirect user, event: :authentication
+  end
+end

--- a/app/views/layouts/home.html.slim
+++ b/app/views/layouts/home.html.slim
@@ -32,13 +32,20 @@ html lang="en"
         br
         br
         br
-        .row
-          .col
-          .col
-            a.btn.btn-block.btn-social.btn-google href="#{url_for  user_google_oauth2_omniauth_authorize_path}"
-              span.fa.fa-google                
-              | Sign in with Google
-          .col
-
-
+        - case Figaro.env.sign_in_type
+        - when 'form'
+          = form_tag user_sign_in_path, method: :post do
+            .row
+              .col-sm-10.offset-sm-1
+                = text_field_tag :name, '', class: 'form-control', placeholder: 'Name', required: true
+                = text_field_tag :email, '', class: 'form-control', placeholder: 'Email', required: true, type: 'email'
+                = submit_tag 'Sign in', class: 'form-control btn-md btn-primary'
+        - else
+          .row
+            .col
+            .col
+              a.btn.btn-block.btn-social.btn-google href="#{url_for user_google_oauth2_omniauth_authorize_path}"
+                span.fa.fa-google
+                | Sign in with Google
+            .col
        

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -17,3 +17,4 @@ DEFAULT_HOST_PATTERN: 's*'
 UID_BUFFER: 5000
 SAML_APPS: 'datadog'
 GATE_URL: 'https://gate.gojek.co.id/'
+SIGN_IN_TYPE: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       end
     end
 
+    post '/users/sign_in' => 'users/auth#log_in', as: 'user_sign_in'
     delete "/users/sign_out" => "devise/sessions#destroy"
     match 'download_vpn', to: 'profile#download_vpn', via: :get, format: :html
     match 'download_vpn_for_ios_and_mac', to: 'profile#download_vpn_for_ios_and_mac', via: :get, format: :html

--- a/spec/controllers/users/auth_controller_spec.rb
+++ b/spec/controllers/users/auth_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Users::AuthController, type: :controller do
+  let(:user) { FactoryBot.create(:user, name: 'foobar', email: 'foobar@foobar.com') }
+
+  context 'sign in' do
+    before(:each) do
+      @cached_domain_env = Figaro.env.gate_hosted_domains
+      @cached_sign_in_type = Figaro.env.sign_in_type
+      ENV['GATE_HOSTED_DOMAINS'] = 'foobar.com'
+      ENV['SIGN_IN_TYPE'] = 'form'
+    end
+
+    after(:each) do
+      ENV['GATE_HOSTED_DOMAINS'] = @cached_domain_env
+      ENV['SIGN_IN_TYPE'] = @cached_sign_in_type
+    end
+
+    it 'should redirect to home when success' do
+      post :log_in, params: { name: user.name, email: user.email }
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'should produce error and unauthorized status when email domain is unsupported' do
+      post :log_in, params: { name: user.name, email: 'foobar@notfoobar.com' }
+
+      expect(response).to have_http_status(401)
+      expect(response.body).to eq('Your domain is unauthorized')
+    end
+
+    it 'should generate two factor auth when success' do
+      post :log_in, params: { name: user.name, email: user.email }
+
+      user.reload
+      expect(user.auth_key).not_to be_nil
+    end
+
+    it 'should set user session when success' do
+      post :log_in, params: { name: user.name, email: user.email }
+
+      expect(subject.current_user).to eq(user)
+    end
+
+    it 'should redirect to home when sign in type is not form' do
+      ENV['SIGN_IN_TYPE'] = 'not_form'
+
+      post :log_in, params: { name: user.name, email: user.email }
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/views/layouts/home.html.slim_spec.rb
+++ b/spec/views/layouts/home.html.slim_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'layouts/home', type: :view do
+  before(:each) do
+    @cached_sign_in_type = Figaro.env.sign_in_type
+  end
+
+  after(:each) do
+    ENV['SIGN_IN_TYPE'] = @cached_sign_in_type
+  end
+
+  it 'should renders google auth link when use default sign in type' do
+    ENV['SIGN_IN_TYPE'] = ''
+
+    render
+
+    assert_select "a[href$='#{user_google_oauth2_omniauth_authorize_path}']"
+  end
+
+  it 'should not renders google auth link when sign in type form' do
+    ENV['SIGN_IN_TYPE'] = 'form'
+
+    render
+
+    assert_select "a[href$='#{user_google_oauth2_omniauth_authorize_path}']", 0
+  end
+
+  it 'renders sign in form' do
+    ENV['SIGN_IN_TYPE'] = 'form'
+
+    render
+
+    assert_select 'form[action=?][method=?]', user_sign_in_path, 'post' do
+      assert_select 'input#name[name=name]'
+      assert_select 'input#email[name=email]'
+    end
+  end
+
+  it 'should not renders sign in form when sign in type is not form' do
+    ENV['SIGN_IN_TYPE'] = 'not_form'
+
+    render
+
+    assert_select 'form[action=?][method=?]', user_sign_in_path, 'post', 0
+  end
+end


### PR DESCRIPTION
* add user sign in route

* sign in only allow authorized domain

* sign in will generate two factor auth

* change sign in method to log in to avoid conflict with devise method

* sign in will set user session

* add spec for home view to render google oauth link

* home view will render sign in form

* home view will render google oauth only if sign in type is google

* home view will render sign in form only if sign in type is form

* refactor home view spec to move env changing to before and after

* sign in route is unusable when sign in type is not form

* home view will render google oauth as default sign in type

* remove caps env from auth controller spec

* update readme to include sign in type setup